### PR TITLE
Add analysis mode toggle for SHAP comparison

### DIFF
--- a/test.py
+++ b/test.py
@@ -55,6 +55,8 @@ TARGET_COL = "Target_Dir"
 TEST_SIZE = 0.2
 MAX_K = 15
 KMEANS_N = 100  # 背景データ要約サンプル数
+# 分析モード: "effect_vs_interaction" または "obs_vs_intervention"
+ANALYSIS_MODE = "effect_vs_interaction"
 
 # ───────────────────────────────────────────────
 # 1. データ取得・前処理
@@ -240,22 +242,37 @@ print("\n4. SHAP / I-SHAP の計算を開始...（時間がかかる場合があ
 kmeans_obj = shap.kmeans(X_tr, KMEANS_N)
 background = getattr(kmeans_obj, "data", np.array(kmeans_obj))
 
-explainer_shap = shap.TreeExplainer(
-    model,
-    data=background,
-    feature_perturbation="interventional",
-)
-explainer_ishap = shap.TreeExplainer(
-    model,
-    data=background,
-    feature_perturbation="interventional",
-)
+if ANALYSIS_MODE == "effect_vs_interaction":
+    explainer_shap = shap.TreeExplainer(
+        model,
+        data=background,
+        feature_perturbation="interventional",
+    )
+    explainer_ishap = shap.TreeExplainer(
+        model,
+        data=background,
+        feature_perturbation="interventional",
+    )
+else:  # "obs_vs_intervention"
+    explainer_shap = shap.TreeExplainer(
+        model,
+        data=background,
+        feature_perturbation="tree_path_dependent",
+    )
+    explainer_ishap = shap.TreeExplainer(
+        model,
+        data=background,
+        feature_perturbation="interventional",
+    )
 
 import contextlib
 with open(os.devnull, "w") as fnull:
     with contextlib.redirect_stderr(fnull):
         shap_vals = explainer_shap.shap_values(X_te)
-        ishap_vals = explainer_ishap.shap_interaction_values(X_te)
+        if ANALYSIS_MODE == "effect_vs_interaction":
+            ishap_vals = explainer_ishap.shap_interaction_values(X_te)
+        else:
+            ishap_vals = explainer_ishap.shap_values(X_te)
 
 if isinstance(shap_vals, list):
     shap_vals = shap_vals[0]
@@ -263,7 +280,10 @@ if isinstance(ishap_vals, list):
     ishap_vals = ishap_vals[0]
 
 mean_abs_shap = np.abs(shap_vals).mean(axis=0)
-mean_abs_ishap = np.abs(ishap_vals).sum(axis=2).mean(axis=0)
+if ANALYSIS_MODE == "effect_vs_interaction":
+    mean_abs_ishap = np.abs(ishap_vals).sum(axis=2).mean(axis=0)
+else:
+    mean_abs_ishap = np.abs(ishap_vals).mean(axis=0)
 
 baseline = X_tr.mean(axis=0)
 orig_preds = pred_proba


### PR DESCRIPTION
## Summary
- add `ANALYSIS_MODE` constant to choose SHAP analysis type
- switch SHAP computation based on the selected mode

## Testing
- `python -m py_compile test.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2a4300a08328ab38dbb8a50c5d66